### PR TITLE
OCPCLOUD-2649: Add openshift/e2e-tests for CAPI E2E testing

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Running e2e-tests.sh"
+
+unset GOFLAGS
+tmp="$(mktemp -d)"
+
+if [ "${PULL_BASE_REF}" == "master" ]; then
+  # the default branch for cluster-capi-operator is main.
+  CCAPIO_BASE_REF="main"
+else
+  CCAPIO_BASE_REF=$PULL_BASE_REF
+fi
+
+echo "cloning github.com/openshift/cluster-capi-operator at branch '$CCAPIO_BASE_REF'"
+git clone --single-branch --branch="$CCAPIO_BASE_REF" --depth=1 "https://github.com/openshift/cluster-capi-operator.git" "$tmp"
+
+echo "running cluster-capi-operator's: make e2e"
+exec make -C "$tmp" e2e


### PR DESCRIPTION
This PR adds a script under openshift/e2e-tests.sh which can be invoked manually or through the OpenShift CI steps (as we already do for [unit tests](https://github.com/openshift/release/blob/ecf68889eb6507167b2a90d8daa95061b430efe2/ci-operator/config/openshift/cluster-api-provider-gcp/openshift-cluster-api-provider-gcp-master.yaml#LL44C1-L47C14)) to launch CAPI E2E tests from within the provider repo.

This mimics the [approach in the MAPI providers](https://github.com/openshift/machine-api-provider-aws/blob/425a29de158582a931fd8052b306f4589ee90b61/hack/e2e.sh#L1C1-L10) where we clone the repo where the e2e tests reside and launch those from within the provider repo PRs.