### PR TITLE
OCPBUGS-61498: Fix openshift/unit-tests.sh

### DIFF
--- a/openshift/unit-tests.sh
+++ b/openshift/unit-tests.sh
@@ -11,4 +11,4 @@ if [ $HOME == "/" ]; then
   export HOME=/tmp/kubebuilder/testing
 fi
 
-GOFLAGS='-mod=readonly' make go-test
+GOFLAGS='-mod=readonly' make test


### PR DESCRIPTION
The path for unit test has changed in the root for the `Makefile`