### PR TITLE
OCPCLOUD-3359: Add TLS substitutions

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -449,6 +449,8 @@ spec:
         - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
         - --v=4
         - --feature-gates=MultiNetworks=${EXP_MULTI_NETWORKS:=false},NodeAntiAffinity=${EXP_NODE_ANTI_AFFINITY:=false},NamespaceScopedZones=${EXP_NAMESPACE_SCOPED_ZONES:=false},NodeAutoPlacement=${EXP_NODE_AUTO_PLACEMENT:=false},PriorityQueue=${EXP_PRIORITY_QUEUE:=false}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -11,3 +11,16 @@ images:
 - name: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller
   newName: registry.ci.openshift.org/openshift
   newTag: vsphere-cluster-api-controllers
+
+# Add TLS configuration args (substituted by cluster-capi-operator revisiongenerator)
+patches:
+- target:
+    kind: Deployment
+    name: capv-controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=${TLS_MIN_VERSION}"
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-cipher-suites=${TLS_CIPHER_SUITES}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configurable TLS options for the controller manager: new settings allow specifying the minimum TLS version and the TLS cipher suites via configuration/placeholders so deployments can inject desired TLS parameters at deploy-time without code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->