### PR TITLE
NO-JIRA: manifests-gen: scope provider webhooks to capi namespace

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -8561,6 +8561,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.vspheredeploymentzone.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8582,6 +8585,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.vspherefailuredomain.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8603,6 +8609,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.vspheremachine.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8624,6 +8633,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.vspherevm.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8655,6 +8667,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.vsphereclustertemplate.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8676,6 +8691,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.vspherefailuredomain.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8697,6 +8715,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.vspheremachine.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8718,6 +8739,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.vspheremachinetemplate.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8739,6 +8763,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.vspherevm.infrastructure.cluster.x-k8s.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io

--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -2,7 +2,7 @@ module tools
 
 go 1.25.0
 
-require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c
+require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c
 
 require (
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -95,8 +95,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80 h1:r0S/yoZAI0iWo1JvoIijaIgWGWf/izg4WiV7Wrtz16k=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c h1:brDtyXDZ8M/6KpJ9rsXQ3KKGawgN4TeiD4NpjFvu3V4=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c h1:mCbdsqRsXvIw22zy5c07zmFpaE/ng6ehx0Pq399UM3w=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
@@ -3,6 +3,31 @@ kind: Component
 
 namespace: openshift-cluster-api
 
+resources:
+  - webhook-namespace-selector.yaml
+
+# Scope all provider webhooks to the openshift-cluster-api namespace.
+# This prevents webhooks from intercepting requests in other namespaces,
+# which would fail on unsupported platforms where the webhook server is not running.
+replacements:
+  - source:
+      kind: ConfigMap
+      name: webhook-namespace-selector
+      fieldPath: data.namespace
+    targets:
+      - select:
+          kind: ValidatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+      - select:
+          kind: MutatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+
 patches:
 
 # Retain Secrets internally for reference tracking, but don't emit them
@@ -14,6 +39,7 @@ patches:
     metadata:
       name: __ignored__
       annotations:
+        # Marks this resource as local-only so kustomize excludes it from the final output.
         config.kubernetes.io/local-config: "true"
 
 # Set OpenShift pod annotations on all Deployments' pod templates.

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/webhook-namespace-selector.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/webhook-namespace-selector.yaml
@@ -1,0 +1,14 @@
+# This ConfigMap is a kustomize workaround: replacements need a concrete source resource
+# to read a value from, but there is no real resource that holds the target namespace.
+# This ConfigMap acts as that source, providing the namespace value to inject into webhook
+# namespaceSelector fields via the replacements defined in kustomization.yaml.
+# It is marked as local-config so kustomize never emits it in the final output.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: webhook-namespace-selector
+  annotations:
+    # Marks this resource as local-only so kustomize excludes it from the final output.
+    config.kubernetes.io/local-config: "true"
+data:
+  namespace: openshift-cluster-api

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/opencontainers/go-digest
 # github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80
 ## explicit; go 1.25.0
 github.com/openshift/api/config/v1
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c
 ## explicit; go 1.25.0
 github.com/openshift/cluster-capi-operator/manifests-gen
 github.com/openshift/cluster-capi-operator/manifests-gen/providermetadata


### PR DESCRIPTION
Bumps `manifests-gen` to include webhook namespace scoping, which adds a `namespaceSelector` to all provider webhooks restricting them to the `openshift-cluster-api` namespace.

This prevents webhooks from intercepting requests in other namespaces, which would fail on unsupported platforms where the webhook server is not running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated manifests generation tooling dependency to latest version
  * Refined webhook configuration scoping in cluster API operator manifests to restrict processing to designated namespaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->