### PR TITLE
OCPBUGS-53005: Remove references to master branch

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -7,12 +7,8 @@ echo "Running e2e-tests.sh"
 unset GOFLAGS
 tmp="$(mktemp -d)"
 
-if [ "${PULL_BASE_REF}" == "master" ]; then
-  # the default branch for cluster-capi-operator is main.
-  CCAPIO_BASE_REF="main"
-else
-  CCAPIO_BASE_REF=$PULL_BASE_REF
-fi
+# Default branch for both CCAPIO and this repo should be `main`.
+CCAPIO_BASE_REF=$PULL_BASE_REF
 
 echo "cloning github.com/openshift/cluster-capi-operator at branch '$CCAPIO_BASE_REF'"
 git clone --single-branch --branch="$CCAPIO_BASE_REF" --depth=1 "https://github.com/openshift/cluster-capi-operator.git" "$tmp"


### PR DESCRIPTION
Remove the `master`→`main` branch translation in `openshift/e2e-tests.sh`, since the default branch for this repo is now `main`.

Mirrors the same change done in https://github.com/openshift/cluster-api/pull/235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified end-to-end test script branch handling to always use the incoming base reference and removed special-case mapping for the default branch. Updated related documentation/comments to reflect the current default branch naming. This reduces ambiguity in test runs and aligns docs with actual behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->